### PR TITLE
Allow configuration of socket io path

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ server.on('request', function(req, res) {
   fs.createReadStream(__dirname + file).pipe(res);
 });
 
-socketio(server, {path: '/tutorials/socket.io'}).of('pty').on('connection', function(socket) {
+socketio(server, {path: '/terminal/socket.io'}).of('pty').on('connection', function(socket) {
   // receives a bidirectional pipe from the client see index.html
   // for the client-side
   ss(socket).on('new', function(stream, options) {

--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ server.on('request', function(req, res) {
   fs.createReadStream(__dirname + file).pipe(res);
 });
 
-socketio(server, {path: '/terminal/socket.io'}).of('pty').on('connection', function(socket) {
+socketio(server, {path: config.socketIO.path}).of('pty').on('connection', function(socket) {
   // receives a bidirectional pipe from the client see index.html
   // for the client-side
   ss(socket).on('new', function(stream, options) {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,8 @@
 {
 	"login": "echo \"Please don't use this in productive environments as all keystrokes are sent in plain text!\"; /bin/sh",
 	"port": 25288,
-	"interface": "127.0.0.1"
+	"interface": "127.0.0.1",
+        "socketIO": {
+          "path": "/tutorials/socket.io"
+        }
 }


### PR DESCRIPTION
Cluster's could have two instances of `flight-tutorials-server` running on them.  One for serving flight tutorials and the other for serving the "login console".

We could adjust the `alces-flight-tutorials` clusterware service so that only one instance would be required, however that service is likely to become obsolete once the tutorials client is delivered by Flight Launch or Forge.  For now, we will stick with having the two instances of `flight-tutorials-server` and customizing the socket io path.